### PR TITLE
Updated Django requirement to allow 1.5.x releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="me@matagus.com.ar",
 
     install_requires=["feedparser", "south", "django-tagging",
-        "django-pagination", "Django==1.5", "BeautifulSoup",
+        "django-pagination", "Django>=1.5", "BeautifulSoup",
         "pinax-theme-bootstrap"],
 
     packages=find_packages(),


### PR DESCRIPTION
A pip install django-planet will currently uninstall Django 1.5.2 to install 1.5.  Thanks!
