### PR TITLE
Pin django-tagging requiment to 0.3.6 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache: pip
 
 install:
     - pip install $REQUIREMENTS
-    - pip install django-tagging
+    - pip install django-tagging==0.3.6
     - pip install django-pagination-py3
     - pip install feedparser
     - pip install pinax-theme-bootstrap

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Required
 
 * Python 2.6+
 * Django 1.6/1.7
-* django-tagging 0.3.6+
+* django-tagging 0.3.6
 * django-pagination 1.0.0+
 * feedparser
 * pinax-theme-bootstrap 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=1.6,<1.8
-django-tagging>=0.3.6
+django-tagging==0.3.6
 django-pagination
 feedparser
 pinax-theme-bootstrap==3.0a4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
 
     install_requires=[
         "feedparser",
-        "django-tagging>=0.3.6",
+        "django-tagging==0.3.6",
         "django-pagination-py3",
         "Django>=1.7",
         "beautifulsoup4",


### PR DESCRIPTION
Since django-tagging 0.4.0dev breaks compatibility